### PR TITLE
Fix: update foldl5 so it uses 5 component sets

### DIFF
--- a/src/Logic/System.elm
+++ b/src/Logic/System.elm
@@ -187,21 +187,23 @@ indexedFoldl4 f comp1 comp2 comp3 comp4 acc_ =
 {-| Same as [`foldl2`](#foldl2) only with 5 components
 -}
 foldl5 :
-    (comp1 -> comp2 -> comp3 -> comp4 -> acc -> acc)
+    (comp1 -> comp2 -> comp3 -> comp4 -> comp5 -> acc -> acc)
     -> Component.Set comp1
     -> Component.Set comp2
     -> Component.Set comp3
     -> Component.Set comp4
+    -> Component.Set comp5
     -> acc
     -> acc
-foldl5 f comp1 comp2 comp3 comp4 acc_ =
+foldl5 f comp1 comp2 comp3 comp4 comp5 acc_ =
     indexedFoldlArray
         (\n value acc ->
-            Maybe.map4 (\a b c d -> f a b c d acc)
+            Maybe.map5 (\a b c d e -> f a b c d e acc)
                 value
                 (Component.get n comp2)
                 (Component.get n comp3)
                 (Component.get n comp4)
+                (Component.get n comp5)
                 |> Maybe.withDefault acc
         )
         acc_


### PR DESCRIPTION
Currently `foldl5` has the same signature as `foldl4` and doesn't take a 5th component spec. Currently my workaround for this is to just use the `indexedFoldl5` version. This will have to be published as a major version change because the function's signature has changed